### PR TITLE
Added the request type parameter to the sequence

### DIFF
--- a/sequence.sv
+++ b/sequence.sv
@@ -1,4 +1,4 @@
-class dummy_seq extends uvm_sequence;
+class dummy_seq extends uvm_sequence #(transaction);
     `uvm_object_utils(dummy_seq)
 
     transaction tr;


### PR DESCRIPTION
According to uvm_guide section 3.10.1 'Specify the request and response item type parameters' (if you specify only the request then the response is from the same type